### PR TITLE
Improved identification of Linux distributions

### DIFF
--- a/scan_hardware
+++ b/scan_hardware
@@ -43,6 +43,7 @@ system ("mkdir $TMPDIR");
 # System information
 print " -> general system information \n";
 system ("lsb_release -a > $TMPDIR/lsb_release.txt");
+system ("cat /etc/*-release >> $TMPDIR/lsb_release.txt");
 system ("cat /proc/version > $TMPDIR/version.txt");
 
 # General HW overview


### PR DESCRIPTION
Added command to gather additional distribution information in case lsb_release is not available (e.g. under Arch Linux).